### PR TITLE
Fix for --dry-run option not working

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -45,9 +45,13 @@ var Migration = function(path, actions){
 
       console.log( sql_steps.join("\n") );
 
-      async.eachSeries(sql_steps, function(sql, next_step){
-        db.query(sql, next_step);
-      }, done);
+      if (!global.dryRun) {
+        async.eachSeries(sql_steps, function(sql, next_step){
+          db.query(sql, next_step);
+        }, done);
+      } else {
+        done();
+      }
     })
   }
   self.applyDown = function(done){
@@ -70,11 +74,14 @@ var Migration = function(path, actions){
       console.log('### MIGRATION '+self.name+' (down) ###')
       console.log( sql );
 
-      db.query(sql, function(err, result){
-        if (err) return done(err);
-
+      if (!global.dryRun) {
+        db.query(sql, function(err, result){
+          if (err) return done(err);
+          done();
+        });
+      } else {
         done();
-      });
+      }
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "async": "^0.2.10"
   },
   "devDependencies": {
-    "pg": "^3.4.1"
+    "pg": "^3.4.1",
+    "rewire": "^2.1.2",
+    "sinon": "^1.11.1"
   },
-  "scripts": {
-
-  }
+  "scripts": {}
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,7 @@
     "rewire": "^2.1.2",
     "sinon": "^1.11.1"
   },
-  "scripts": {}
+  "scripts": {
+    "test": "mocha test"
+  }
 }

--- a/test/1414549381268_names.js
+++ b/test/1414549381268_names.js
@@ -1,0 +1,14 @@
+exports.up = function(pgm, run) {
+
+  pgm.createTable( 'names', {
+    id: 'id',
+    name: { type: 'varchar(10)' }
+    });
+  run();
+};
+
+exports.down = function(pgm, run) {
+
+  pgm.dropTable( 'names' );
+  run();
+};

--- a/test/migration_test.js
+++ b/test/migration_test.js
@@ -1,0 +1,30 @@
+var rewire    = require('rewire');
+var Migration = rewire('../lib/migration');
+var actions   = require('./1414549381268_names');
+var sinon     = require('sinon');
+var assert    = require('assert');
+
+var migration;
+
+describe('lib/migration', function () {
+  var dbMock = {};
+
+  before(function () {
+    Migration.__set__({
+      'db': dbMock
+    });
+    migration = new Migration( '1414549381268_names.js', actions);
+  });
+
+  describe('self.applyUp', function () {
+
+    it('self.applyUp', function (done) {
+      dbMock.query = sinon.stub();
+      var next = sinon.stub();
+      migration.applyUp(next);
+      assert.equal(dbMock.query.calledOnce, true);
+      done();
+    });
+  });
+
+});

--- a/test/migration_test.js
+++ b/test/migration_test.js
@@ -8,6 +8,7 @@ var migration;
 
 describe('lib/migration', function () {
   var dbMock = {};
+  var done;
 
   before(function () {
     Migration.__set__({
@@ -16,14 +17,38 @@ describe('lib/migration', function () {
     migration = new Migration( '1414549381268_names.js', actions);
   });
 
+  beforeEach(function () {
+    dbMock.query = sinon.spy();
+    done = sinon.mock();
+  });
+
   describe('self.applyUp', function () {
 
-    it('self.applyUp', function (done) {
-      dbMock.query = sinon.stub();
-      var next = sinon.stub();
-      migration.applyUp(next);
+    it('normal operations: db.query should be called', function () {
+      migration.applyUp(done);
       assert.equal(dbMock.query.calledOnce, true);
-      done();
+    });
+
+    it('--dry-run option: db.query should not be called', function () {
+      global.dryRun = true;
+      migration.applyUp(done);
+      assert.equal(dbMock.query.called, false);
+      global.dryRun = false;
+    });
+  });
+
+  describe('self.applyDown', function () {
+
+    it('normal operations: db.query should be called', function () {
+      migration.applyDown(done);
+      assert.equal(dbMock.query.calledOnce, true);
+    });
+
+    it('--dry-run option: db.query should not be called', function () {
+      global.dryRun = true;
+      migration.applyDown(done);
+      assert.equal(dbMock.query.called, false);
+      global.dryRun = false;
     });
   });
 


### PR DESCRIPTION
Running pg-migrate with the dry run option i.e `pg-migrate [up | down] --dry-run` does not modify pg-migrates's behavior. It sets 'global.dryRun' but this is never used by any code.

Here is a fix complete with tests. As regards testing I used [Mocha](https://github.com/mochajs/mocha) as the test runner (installed as globally) and [Rewire](https://github.com/jhnns/rewire) and [Sinon](https://github.com/cjohansen/Sinon.JS) to isolate the test code.

I am happy to change my pull request if you want to use some other test framework.