### PR TITLE
Don't escape the default value

### DIFF
--- a/lib/operations/tables.js
+++ b/lib/operations/tables.js
@@ -175,7 +175,7 @@ function parseColumns ( columns ){
     return utils.t('{column_name} {type}{default}{constraints}', {
       column_name: column_name,
       type: type,
-      default: options.default !== undefined ? ' DEFAULT '+utils.escapeValue(options.default) : '',
+      default: options.default !== undefined ? ' DEFAULT '+options.default : '',
       constraints: constraints.length ? ' '+constraints.join(' ') : ''
     });
 


### PR DESCRIPTION
Allows for SQL functions such as `now()` or `uuid_in(md5(random()::text || now()::text)::cstring)` to be used.