### PR TITLE
Added quotations to the table name when creating an index

### DIFF
--- a/lib/operations/indexes.js
+++ b/lib/operations/indexes.js
@@ -17,7 +17,7 @@ var ops = module.exports = {
     options = options || {};
     if ( _.isArray(columns) ) columns = columns.join(', ');
 
-    var sql = utils.t('CREATE {unique} INDEX {concurrently}{index_name} ON {table_name}{method} ({columns}){where};', {
+    var sql = utils.t('CREATE {unique} INDEX {concurrently}{index_name} ON \"{table_name}\"{method} ({columns}){where};', {
         table_name   : table_name,
         index_name   : generateIndexName( table_name, columns, options ),
         columns      : columns,


### PR DESCRIPTION
I was getting errors when creating indices because the table name was not found. This change puts the index creation statement in line with the table creation statement.