### PR TITLE
Migration files selection rewrite

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -23,70 +23,70 @@ module.exports = function MigrationRunner(options){
       function fetchCompletedMigrations(err){
         db.query("SELECT * FROM "+options.migrations_table+" ORDER BY run_on", this)
       },
-	    function determineMigrationsToRun(err, result){
-		    if (err) return callback(err);
-		    if (!result || !result.rows) return callback(new Error('Unable to fetch migrations from pgmigrations table'));
+      function determineMigrationsToRun(err, result) {
+        if(err) return callback(err);
+        if(!result || !result.rows) return callback(new Error('Unable to fetch migrations from pgmigrations table'));
 
-		    //store done migration names
-		    var runNames = result.rows.map(function(row){
-			    return row.name;
-		    });
+        //store done migration names
+        var runNames = result.rows.map(function(row) {
+          return row.name;
+        });
 
-		    var doneMigrations = [];
-		    var runMigrations = [];
+        var doneMigrations = [];
+        var runMigrations = [];
 
-				//filter out undone and done migrations from list of files
-		    for (var i=0; i<migrations.length; i++){
-			    if ( runNames.indexOf(migrations[i].name) < 0 ){
+        //filter out undone and done migrations from list of files
+        for(var i = 0; i < migrations.length; i++) {
+          if(runNames.indexOf(migrations[i].name) < 0) {
 
-				    //if specific migration file is requested
-				    if (options.file && options.file == migrations[i].name){
-					    runMigrations = [migrations[i]];
-					    break;
-				    }
-				    runMigrations.push(migrations[i]);
-			    }else{
-				    doneMigrations.push(migrations[i])
-			    }
+            //if specific migration file is requested
+            if(options.file && options.file == migrations[i].name) {
+              runMigrations = [migrations[i]];
+              break;
+            }
+            runMigrations.push(migrations[i]);
+          } else {
+            doneMigrations.push(migrations[i])
+          }
 
-		    }
+        }
 
-				//final selection will go here
-		    var to_run;
+        //final selection will go here
+        var to_run;
 
-		    //down gets by default one migration at the time, if not set otherwise
-		    if(options.direction=='down'){
-			    to_run = doneMigrations.slice(-1);
-			  //up gets all undone migrations by default
-		    }else{
-			    to_run = runMigrations;
-		    }
+        //down gets by default one migration at the time, if not set otherwise
+        if(options.direction == 'down') {
+          to_run = doneMigrations.slice(-1);
+          //up gets all undone migrations by default
+        } else {
+          to_run = runMigrations;
+        }
 
-		    //if specific count of migrations is requested
-		    if (options.count){
-			    // infinity is set in the bin file
-			    if (options.count !== Infinity){
-				    if(options.direction=='up'){
-					    to_run = runMigrations.slice(0, options.count);
-				    }else{
-					    to_run = doneMigrations.slice(options.count * -1);
-				    }
-			    }
-		    }
+        //if specific count of migrations is requested
+        if(options.count) {
+          // infinity is set in the bin file
+          if(options.count !== Infinity) {
+            if(options.direction == 'up') {
+              to_run = runMigrations.slice(0, options.count);
+            } else {
+              to_run = doneMigrations.slice(options.count * -1);
+            }
+          }
+        }
 
-		    if (!to_run.length) {
-			    console.log('No migrations to run!');
-			    return callback();
-		    }
+        if(!to_run.length) {
+          console.log('No migrations to run!');
+          return callback();
+        }
 
-		    // TODO: add some fancy colors to logging
-		    console.log('> Migrating files:' );
-		    for(var i in to_run){
-			    console.log('> - ' + to_run[i].name );
-		    }
+        // TODO: add some fancy colors to logging
+        console.log('> Migrating files:');
+        for(var i in to_run) {
+          console.log('> - ' + to_run[i].name);
+        }
 
-		    this(null, to_run);
-	    },
+        this(null, to_run);
+      },
       function runMigrations(err, migrations_to_run){
         if (err) return callback(err);
         async.eachSeries(migrations_to_run, function(m, next){

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -23,59 +23,70 @@ module.exports = function MigrationRunner(options){
       function fetchCompletedMigrations(err){
         db.query("SELECT * FROM "+options.migrations_table+" ORDER BY run_on", this)
       },
-      function determineMigrationsToRun(err, result){
-        if (err) return callback(err);
-        if (!result || !result.rows) return callback(new Error('Unable to fetch migrations from '+options.migrations_table+' table'));
+	    function determineMigrationsToRun(err, result){
+		    if (err) return callback(err);
+		    if (!result || !result.rows) return callback(new Error('Unable to fetch migrations from pgmigrations table'));
 
-        // TODO: handle merging of migrations that are out of order better
-        // show a warning and add an option to apply missing migraitons
+		    //store done migration names
+		    var runNames = result.rows.map(function(row){
+			    return row.name;
+		    });
 
-        // go through each existing migration and verify the file exists
-        // store the index so we know where we are starting
-        for (var i=0; i<result.rows.length; i++){
-          // console.log( '"' + result.rows[i].name + '" -- "' + migrations[i].name + '"' );
-          if ( result.rows[i].name !== migrations[i].name ){
-            return callback(new Error('Migration file missing for already ran migration: '+result.rows[i].name))
-          }
-          if (options.file && options.file == migrations[i].name){
-            migrate_to_index = i;
-          }
-        }
-        current_index = result.rows.length;
+		    var doneMigrations = [];
+		    var runMigrations = [];
 
-        if (options.count){
-          // infinity is set in the bin file
-          if (options.count == Infinity){
-            migrate_to_index = migrations.length;
-          } else {
-            // users can also specify the number of migrations to move up and down
-            migrate_to_index = current_index + options.count * (options.direction=='up' ?1:-1);
-          }
-        }
+				//filter out undone and done migrations from list of files
+		    for (var i=0; i<migrations.length; i++){
+			    if ( runNames.indexOf(migrations[i].name) < 0 ){
 
-        // 0 is a clean slate (no migrations run)
-        if (migrate_to_index < 0) return callback(new Error('cannot migrate past the starting position'));
-        if (migrate_to_index > migrations.length ) return callback(new Error('Cannot migrate past the last migration defined'));
-        if (current_index == migrate_to_index) {
-          console.log('No migrations to run!');
-          return callback();
-        }
+				    //if specific migration file is requested
+				    if (options.file && options.file == migrations[i].name){
+					    runMigrations = [migrations[i]];
+					    break;
+				    }
+				    runMigrations.push(migrations[i]);
+			    }else{
+				    doneMigrations.push(migrations[i])
+			    }
 
-        var to_run;
-        if (options.direction == 'up'){
-          to_run = migrations.slice(current_index, migrate_to_index);
-        } else {
-          to_run = migrations.slice(migrate_to_index, current_index);
-          to_run = to_run.reverse();
-        }
+		    }
 
-        // TODO: add some fancy colors to logging
-        var current_state_name = current_index == 0 ? 'CLEAN SLATE' : migrations[current_index-1].name;
-        var new_state_name = migrate_to_index == 0 ? 'CLEAN SLATE' : migrations[migrate_to_index-1].name;
-        console.log('> Migrating from '+current_state_name + ' >to> ' + new_state_name );
+				//final selection will go here
+		    var to_run;
 
-        this(null, to_run);
-      },
+		    //down gets by default one migration at the time, if not set otherwise
+		    if(options.direction=='down'){
+			    to_run = doneMigrations.slice(-1);
+			  //up gets all undone migrations by default
+		    }else{
+			    to_run = runMigrations;
+		    }
+
+		    //if specific count of migrations is requested
+		    if (options.count){
+			    // infinity is set in the bin file
+			    if (options.count !== Infinity){
+				    if(options.direction=='up'){
+					    to_run = runMigrations.slice(0, options.count);
+				    }else{
+					    to_run = doneMigrations.slice(options.count * -1);
+				    }
+			    }
+		    }
+
+		    if (!to_run.length) {
+			    console.log('No migrations to run!');
+			    return callback();
+		    }
+
+		    // TODO: add some fancy colors to logging
+		    console.log('> Migrating files:' );
+		    for(var i in to_run){
+			    console.log('> - ' + to_run[i].name );
+		    }
+
+		    this(null, to_run);
+	    },
       function runMigrations(err, migrations_to_run){
         if (err) return callback(err);
         async.eachSeries(migrations_to_run, function(m, next){


### PR DESCRIPTION
This is needed to allow migrating files, which have been earlier timestamp than the latest migrated file.
When developing with GIT and in a team, this can very easily become a problem.

Lets say I have developed some functionality and in my migrations folder I have these items:
* 10_init.js
* 20_users.js
* 30_permissions.js

Then I will do a migrate up and all these files are imported, nice.

Now my teammate has also done some work during this period, I merge his changes in and my migrations folder now looks like this:
* 10_init.js
* 11_content.js
* 20_users.js
* 30_permissions.js

I try to do a migrate up, and I get an error, saying that:
`Migration file missing for already ran migration: 20_users`
Crazy right? It also blocks me from doing a migrate down.

So this change fixes all this and hopefully other people find this useful.
