### PR TITLE
db.init(connection_string) now uses connection_string to connect db

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -6,13 +6,12 @@ var pg = require('pg');
 //or native libpq bindings
 //var pg = require('pg').native
 
-var connection_string = process.env.DATABASE_URL;
 var client;
 var client_active = false;
 
 module.exports.init = function(conenction_string){
-  client = new pg.Client(connection_string);
-}
+  client = new pg.Client(conenction_string || process.env.DATABASE_URL);
+};
 
 module.exports.query = function(query, callback){
   createConnection(function(err){
@@ -25,16 +24,16 @@ module.exports.query = function(query, callback){
     });
 
   });
-}
+};
 
 module.exports.close = function(){
   client.end();
-}
+};
 
 
 function createConnection(callback){
   if (client_active) return callback();
-  
+
   client.connect(function(err){
     if (err) {
       console.error('could not connect to postgres', err);


### PR DESCRIPTION
Right now ```connection_string``` parameter in ```db.init(connection_string)``` is not used and instead the databaseUrl will be taken from the env (process.env.DATABASE_URL).
In order to use multiple databases/hosts etc. it would be a lot more useful to be able to pass the connection url.