### PR TITLE
Added quotes around column names

### DIFF
--- a/lib/operations/tables.js
+++ b/lib/operations/tables.js
@@ -172,7 +172,7 @@ function parseColumns ( columns ){
       constraints.push('REFERENCES '+options.references);
     }
 
-    return utils.t('{column_name} {type}{default}{constraints}', {
+    return utils.t('\"{column_name}\" {type}{default}{constraints}', {
       column_name: column_name,
       type: type,
       default: options.default !== undefined ? ' DEFAULT '+utils.escapeValue(options.default) : '',


### PR DESCRIPTION
Relevant to #5. Query without quotes around column names transforms them to lower case.