### PR TITLE
Avoid unnecessary error output from dotenv

### DIFF
--- a/bin/pg-migrate
+++ b/bin/pg-migrate
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-require('dotenv').load();
+require('dotenv').load({ silent: true });
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');

--- a/bin/pg-migrate
+++ b/bin/pg-migrate
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
 require('dotenv').load({ silent: true });
+if(!process.env.DATABASE_URL) {
+  console.error('The $DATABASE_URL environment variable is not set.')
+  process.exit(1)
+}
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');


### PR DESCRIPTION
There are many situations in which the environment variables are already configured (e.g.: running `heroku run pg-migrate up`) and there's no need to load the .env file from dotenv. In these situations, even though the migrations actually run, the console output shows the error stack trace from dotenv. Is quite verbose and confusing at first:

```
Running pg-migrate up on ⬢ testapplication... up, run.5423
{ Error: ENOENT: no such file or directory, open '.env'
    at Error (native)
    at Object.fs.openSync (fs.js:634:18)
    at Object.fs.readFileSync (fs.js:502:33)
    at Object.module.exports.config (/app/node_modules/dotenv/lib/main.js:30:37)
    at Object.<anonymous> (/app/node_modules/node-pg-migrate/bin/pg-migrate:3:19)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3) errno: -2, code: 'ENOENT', syscall: 'open', path: '.env' }
No migrations to run!
Migrations complete!
```

This pull request adds the option `{ silent: true }` when calling `dotenv.load()`, suppressing those (not very useful) error messages from the console output. If in any case after trying to load the .env file the `DATABASE_URL` environment variable is still not available, the program exits with code 1 and outputs a more informative error message to stderr:

```
$ pg-migrate up
The $DATABASE_URL environment variable is not set.
```
