### PR TITLE
Fix order of mirations when migrating down

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -69,7 +69,7 @@ module.exports = function MigrationRunner(options){
             if(options.direction == 'up') {
               to_run = runMigrations.slice(0, options.count);
             } else {
-              to_run = doneMigrations.slice(options.count * -1);
+              to_run = doneMigrations.slice(options.count * -1).reverse();
             }
           }
         }


### PR DESCRIPTION
When migrating down, migrations should run in reverse order then when migrating up
