### PR TITLE
Ability to use schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,19 @@ is equivalent to
 is equivalent to
 `pgm.addColumns('myTable', { id: { type: 'serial', primaryKey: true } });`
 
+### Using schemas
 
+Instead of passing string as name to `pgm` functions, you can pass an object with keys `schema` and `name`. E.g.
 
+`pgm.createTable( {schema: 'my_schema', name: 'my_table_name'}, {id: 'serial'});`
+
+will generate
+
+```sql
+CREATE TABLE "my_schema"."my_table_name" (
+ "id" serial
+);
+```
 
 
 ## Explanation & Goals

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -32,7 +32,7 @@ var Migration = function(migrationPath, actions, options) {
       console.log('### MIGRATION ' + self.name + ' (up) ###');
 
       var sql_steps = pgm.getSqlSteps();
-      sql_steps.push(utils.t('INSERT INTO "' + options.migrations_table + '" (name, run_on) VALUES (\'{name}\', NOW());', { name: self.name }));
+      sql_steps.push(utils.t('INSERT INTO "{table}" (name, run_on) VALUES (\'{name}\', NOW());', { table: options.migrations_table, name: self.name }));
 
       if (pgm.use_transaction) {
         // wrap in a transaction, combine into one sql statement
@@ -75,7 +75,7 @@ var Migration = function(migrationPath, actions, options) {
       console.log('### MIGRATION ' + self.name + ' (down) ###');
 
       var sql_steps = pgm.getSqlSteps();
-      sql_steps.push(utils.t('DELETE FROM "' + options.migrations_table + '" WHERE name=\'{name}\';', { name: self.name }));
+      sql_steps.push(utils.t('DELETE FROM "{table}" WHERE name=\'{name}\';', { table: options.migrations_table, name: self.name }));
 
       if (pgm.use_transaction) {
         // wrap in a transaction, combine into one sql statement

--- a/lib/operations/indexes.js
+++ b/lib/operations/indexes.js
@@ -35,7 +35,7 @@ var ops = module.exports = {
      */
     options = options || {}; // eslint-disable-line no-param-reassign
 
-    var sql = utils.t('CREATE {unique} INDEX {concurrently}{index_name} ON "{table_name}"{method} ({columns}){where};', {
+    var sql = utils.t('CREATE {unique} INDEX {concurrently} "{index_name}" ON "{table_name}"{method} ({columns}){where};', {
       table_name: table_name,
       index_name: generateIndexName(table_name, columns, options),
       columns: generateColumnsString(columns),
@@ -52,7 +52,7 @@ var ops = module.exports = {
     options = options || {}; // eslint-disable-line no-param-reassign
 
     var index_name = generateIndexName(table_name, columns, options);
-    return utils.t('DROP INDEX {index};', { index: index_name });
+    return utils.t('DROP INDEX "{index}";', { index: index_name });
   },
 };
 

--- a/lib/operations/tables.js
+++ b/lib/operations/tables.js
@@ -127,7 +127,7 @@ var ops = module.exports = {
 
   // RENAME
   renameTable: function(table_name, new_name) {
-    return utils.t('ALTER TABLE "{table_name}" RENAME TO {new_name};', {
+    return utils.t('ALTER TABLE "{table_name}" RENAME TO "{new_name}";', {
       table_name: table_name,
       new_name: new_name,
     });
@@ -136,7 +136,7 @@ var ops = module.exports = {
     module.exports.renameTable(new_name, table_name);
   },
   renameColumn: function(table_name, column_name, new_name) {
-    return utils.t('ALTER TABLE "{table_name}" RENAME {column} TO {new_name};', {
+    return utils.t('ALTER TABLE "{table_name}" RENAME "{column}" TO "{new_name}";', {
       table_name: table_name,
       column: column_name,
       new_name: new_name,
@@ -150,12 +150,12 @@ var ops = module.exports = {
   addConstraint: function(table_name, constraint_name, expression) {
     return utils.t('ALTER TABLE "{table_name}" ADD{constraint_name} {constraint};', {
       table_name: table_name,
-      constraint_name: constraint_name ? ' CONSTRAINT ' + constraint_name : '',
+      constraint_name: constraint_name ? ' CONSTRAINT "' + constraint_name + '"' : '',
       constraint: expression,
     });
   },
   dropConstraint: function(table_name, constraint_name) {
-    return utils.t('ALTER TABLE "{table_name}" DROP CONSTRAINT {constraint_name};', {
+    return utils.t('ALTER TABLE "{table_name}" DROP CONSTRAINT "{constraint_name}";', {
       table_name: table_name,
       constraint_name: constraint_name,
     });
@@ -163,13 +163,13 @@ var ops = module.exports = {
 
 
   createType: function(type_name, options) {
-    return utils.t('CREATE TYPE {type_name} AS ENUM (\'{opts}\');', {
+    return utils.t('CREATE TYPE "{type_name}" AS ENUM (\'{opts}\');', {
       type_name: type_name,
       opts: options.join('\', \''),
     });
   },
   dropType: function(type_name) {
-    return utils.t('DROP TYPE {type_name};', { type_name: type_name });
+    return utils.t('DROP TYPE "{type_name}";', { type_name: type_name });
   },
   alterType: function() {
   },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,13 @@ module.exports = {
     return Object
       .keys(d || {})
       .reduce(function(str, p) {
-        return str.replace(new RegExp('{' + p + '}', 'g'), d[p]);
+        var newSubstr = d[p];
+        if (typeof d[p] === 'object') {
+          var schema = d[p].schema;
+          var name = d[p].name;
+          newSubstr = (schema ? schema + '"."' : '') + name;
+        }
+        return str.replace(new RegExp('{' + p + '}', 'g'), newSubstr);
       }, s);
   },
   escapeValue: function(val) {

--- a/test/tables-test.js
+++ b/test/tables-test.js
@@ -1,0 +1,13 @@
+var Tables = require('../lib/operations/tables');
+var assert = require('assert');
+
+describe('lib/operations/tables', function() {
+  describe('.create', function() {
+    it('check schemas can be used', function() {
+      var sql = Tables.create({ schema: 'my_schema', name: 'my_table_name' }, { id: 'serial' });
+      assert.equal(sql, 'CREATE TABLE "my_schema"."my_table_name" (\n\
+  "id" serial\n\
+);');
+    });
+  });
+});


### PR DESCRIPTION
Added ability to use schemas (https://github.com/theoephraim/node-pg-migrate/issues/11)
You can now pass object as a name with keys `schema` and `name` and it will produce correct queries. (https://github.com/theoephraim/node-pg-migrate/blob/fb16636360430a8897e058947f2f857bdf85ed5e/README.md#using-schemas)