### PR TITLE
Migrations in order

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ You can adjust defaults by passing arguments to `pg-migrate`:
 * `migrations-schema` (`s`) - The schema storing table which migrations have been run (defaults to `public`)
 * `migrations-table` (`t`) - The table storing which migrations have been run (defaults to `pgmigrations`)
 
+* `check-order` - Check order of migrations before running them. (There should be no migration with timestamp lesser than last run migration.)
+
 See all by running `pg-migrate --help`.
 
 

--- a/bin/pg-migrate
+++ b/bin/pg-migrate
@@ -109,11 +109,6 @@ if (action === 'create') {
     } else {
       migration_name = argv._.join('-').replace(/_ /g, '-');
     }
-  } else {
-    if (num_migrations === undefined) {
-      if (action === 'up') num_migrations = Infinity;
-      if (action === 'down') num_migrations = 1;
-    }
   }
 
   var runner = new MigrationRunner({

--- a/bin/pg-migrate
+++ b/bin/pg-migrate
@@ -46,6 +46,9 @@ var argv = optimist
   .describe('dry-run', 'Prints the SQL but doesn\'t run it.')
   .boolean('dry-run')
 
+  .describe('check-order', 'Check order of migrations before running them.')
+  .boolean('check-order')
+
   .describe('verbose', 'Verbose mode.')
   .alias('v', 'verbose')
   .boolean('v')
@@ -119,6 +122,7 @@ if (action === 'create') {
     direction: action,
     count: num_migrations,
     file: migration_name,
+    checkOrder: argv['check-order'],
   });
 
   runner.run(function(err) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -94,24 +94,12 @@ module.exports = function MigrationRunner(options) {
         // final selection will go here
         var to_run;
 
-        // down gets by default one migration at the time, if not set otherwise
         if (options.direction === 'down') {
-          to_run = doneMigrations.slice(-1);
-          // up gets all undone migrations by default
+          // down gets by default one migration at the time, if not set otherwise
+          to_run = doneMigrations.slice(options.count ? -Math.abs(options.count) : -1).reverse();
         } else {
-          to_run = runMigrations;
-        }
-
-        // if specific count of migrations is requested
-        if (options.count) {
-          // infinity is set in the bin file
-          if (options.count !== Infinity) {
-            if (options.direction === 'up') {
-              to_run = runMigrations.slice(0, options.count);
-            } else {
-              to_run = doneMigrations.slice(options.count * -1).reverse();
-            }
-          }
+          // up gets all undone migrations by default
+          to_run = runMigrations.slice(0, Math.abs(options.count || Infinity));
         }
 
         if (!to_run.length) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -69,35 +69,16 @@ module.exports = function MigrationRunner(options) {
         if (err) return exitCallback(err);
         if (!result || !result.rows) return exitCallback(new Error('Unable to fetch migrations from ' + options.migrations_schema + '.' + options.migrations_table + ' table'));
 
-        var i;
-
         // store done migration names
         var runNames = result.rows.map(function(row) {
           return row.name;
         });
 
         if (options.checkOrder) {
-          for (i = 0; i < runNames.length; i++) {
+          for (var i = 0; i < runNames.length; i++) {
             if (runNames[i] !== migrations[i].name) {
               return exitCallback(new Error('Not run migration ' + migrations[i].name + ' is preceding already run migration ' + runNames[i]));
             }
-          }
-        }
-
-        var doneMigrations = [];
-        var runMigrations = [];
-
-        // filter out undone and done migrations from list of files
-        for (i = 0; i < migrations.length; i++) {
-          if (runNames.indexOf(migrations[i].name) < 0) {
-            // if specific migration file is requested
-            if (options.file && options.file === migrations[i].name) {
-              runMigrations = [ migrations[i] ];
-              break;
-            }
-            runMigrations.push(migrations[i]);
-          } else {
-            doneMigrations.push(migrations[i]);
           }
         }
 
@@ -105,11 +86,29 @@ module.exports = function MigrationRunner(options) {
         var to_run;
 
         if (options.direction === 'down') {
-          // down gets by default one migration at the time, if not set otherwise
-          to_run = doneMigrations.slice(options.count ? -Math.abs(options.count) : -1).reverse();
+          to_run = runNames
+            .filter(function(migration_name) {
+              return !options.file || options.file === migration_name;
+            })
+            .map(function(migration_name) {
+              return migrations.find(function(migration) {
+                return migration.name === migration_name;
+              }) || migration_name;
+            })
+            .slice(-Math.abs(options.count || 1))
+            .reverse();
+          var deletedMigrations = to_run.filter(function(migration) {
+            return typeof migration === 'string';
+          });
+          if (deletedMigrations.length) {
+            return exitCallback(new Error('Definitions of migrations ' + deletedMigrations.join(', ') + ' have been deleted.'));
+          }
         } else {
-          // up gets all undone migrations by default
-          to_run = runMigrations.slice(0, Math.abs(options.count || Infinity));
+          to_run = migrations
+            .filter(function(migration) {
+              return runNames.indexOf(migration.name) < 0 && (!options.file || options.file === migration.name);
+            })
+            .slice(0, Math.abs(options.count || Infinity));
         }
 
         if (!to_run.length) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -69,16 +69,26 @@ module.exports = function MigrationRunner(options) {
         if (err) return exitCallback(err);
         if (!result || !result.rows) return exitCallback(new Error('Unable to fetch migrations from ' + options.migrations_schema + '.' + options.migrations_table + ' table'));
 
+        var i;
+
         // store done migration names
         var runNames = result.rows.map(function(row) {
           return row.name;
         });
 
+        if (options.checkOrder) {
+          for (i = 0; i < runNames.length; i++) {
+            if (runNames[i] !== migrations[i].name) {
+              return exitCallback(new Error('Not run migration ' + migrations[i].name + ' is preceding already run migration ' + runNames[i]));
+            }
+          }
+        }
+
         var doneMigrations = [];
         var runMigrations = [];
 
         // filter out undone and done migrations from list of files
-        for (var i = 0; i < migrations.length; i++) {
+        for (i = 0; i < migrations.length; i++) {
           if (runNames.indexOf(migrations[i].name) < 0) {
             // if specific migration file is requested
             if (options.file && options.file === migrations[i].name) {


### PR DESCRIPTION
Added flag for checking that there are no migrations with timestamp lesser than last already run migration.
Also when this flag is not used, migration down runs migrations in order they were applied instead of running them in order of timestamps in filenames.