### PR TITLE
Allow createType to be used for composite types

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,11 +269,12 @@ This is required for some SQL operations that cannot be run within a transaction
 
 #### `pgm.createType( type_name, values )`
 
-> Create a new enum data type - [postgres docs](http://www.postgresql.org/docs/9.3/static/sql-createtype.html)
+
+> Create a new data type - [postgres docs](http://www.postgresql.org/docs/9.3/static/sql-createtype.html)
 
 **Arguments:**
 - `type_name` _[string]_ - name of the new type
-- `values` _[array of strings]_ - possible values
+- `values` _[array of strings or object]_ if an array the contents are possible values for an enum type, if an object names and types for a composite type
 
 **Aliases:** `addType`
 **Reverse Operation:** `dropType`

--- a/lib/operations/tables.js
+++ b/lib/operations/tables.js
@@ -191,10 +191,17 @@ var ops = module.exports = {
 
 
   createType: function(type_name, options) {
-    return utils.t('CREATE TYPE "{type_name}" AS ENUM (\'{opts}\');', {
-      type_name: type_name,
-      opts: options.join('\', \''),
-    });
+    if (_.isArray(options)) {
+      return utils.t('CREATE TYPE "{type_name}" AS ENUM (\'{opts}\');', {
+        type_name: type_name,
+        opts: options.join('\', \''),
+      });
+    } else {
+      return utils.t('CREATE TYPE "{type_name}" AS (\n{columns}\n);', {
+        type_name: type_name,
+        columns: parseColumns(options),
+      });
+    }
   },
   dropType: function(type_name) {
     return utils.t('DROP TYPE "{type_name}";', { type_name: type_name });


### PR DESCRIPTION
If the `options` passed to `createType` isn't an array treat it as a set
of attributes for a composite type. This is the only form of type
creation that conforms to the SQL standard.

This does leave creation of range and base types unsupported, and may
make it more difficult to add support for those in the future. But,
those types would generally also require defining functions which is
also not supported by a helper; so anyone wanting to create those types
is likely to need to use raw SQL anyway.