### PR TITLE
Avoid use of `ex:`

### DIFF
--- a/lib/migration-builder.js
+++ b/lib/migration-builder.js
@@ -95,7 +95,7 @@ var MigrationBuilder = function() {
 
   // Other utilities which may be useful
   // .func creates a string which will not be escaped
-  // common uses are for PG functions, ex: { ... default: pgm.func('NOW()') }
+  // common uses are for PG functions, example: { ... default: pgm.func('NOW()') }
   this.func = utils.PgLiteral.create;
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,7 +26,7 @@ module.exports = {
       }, s);
   },
   escapeValue: function(val) {
-    // TODO: figure out a solution for unescaping functions -- ex: NOW()
+    // TODO: figure out a solution for unescaping functions -- example: NOW()
     if (val === null) return 'NULL';
     if (typeof val === 'boolean') return val.toString();
     if (typeof val === 'string') return '\'' + escape(val) + '\'';


### PR DESCRIPTION
When Vim's modeline support is enabled, the string ` ex: ` near the
beginning or end of a file will be interpreted as an attempt to set
options and cause errors to be displayed when the file is opened. Avoid
use of this string to help out Vim users.