### PR TITLE
Locking migrtions

### DIFF
--- a/bin/pg-migrate
+++ b/bin/pg-migrate
@@ -4,7 +4,7 @@
 const util = require('util');
 const yargs = require('yargs');
 const Migration = require('../dist/migration').default; // eslint-disable-line import/no-unresolved,import/extensions
-const migrationRunner = require('../dist/runner').default; // eslint-disable-line import/no-unresolved,import/extensions
+const { default: migrationRunner, unlockRunner } = require('../dist/runner'); // eslint-disable-line import/no-unresolved,import/extensions
 
 process.on('uncaughtException', (err) => {
   console.log(err.stack);
@@ -28,7 +28,7 @@ const checkOrder = 'check-order';
 const configValue = 'config-value';
 
 const argv = yargs
-  .usage('Usage: db-migrate [up|down|create] migrationName [options]')
+  .usage('Usage: db-migrate [up|down|create|unlock] [migrationName] [options]')
 
   .option('d', {
     alias: databaseUrlVar,
@@ -155,6 +155,25 @@ if (action === 'create') {
 
   const migration = Migration.create(new_migration_name, MIGRATIONS_DIR);
   console.log(util.format('Created migration -- %s', migration.path));
+} else if (action === 'unlock') {
+  if (!DATABASE_URL) {
+    console.error(`The $${argv[databaseUrlVar]} environment variable is not set.`);
+    process.exit(1);
+  }
+  unlockRunner({
+    database_url: DATABASE_URL,
+    schema: SCHEMA,
+    migrations_schema: MIGRATIONS_SCHEMA,
+    migrations_table: MIGRATIONS_TABLE,
+  })
+    .then(() => {
+      console.log('Unlocked!');
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.log(err.stack);
+      process.exit(1);
+    });
 } else if (action === 'up' || action === 'down') {
   if (!DATABASE_URL) {
     console.error(`The $${argv[databaseUrlVar]} environment variable is not set.`);

--- a/lib/db.js
+++ b/lib/db.js
@@ -9,6 +9,7 @@ import pg from 'pg';
 export default (connection_string) => {
   const client = new pg.Client(connection_string);
   let client_active = false;
+  const beforeCloseListeners = [];
 
   const createConnection = () =>
     new Promise((resolve, reject) => (
@@ -36,7 +37,7 @@ export default (connection_string) => {
           ))
         )
       )
-      .catch(err => {
+      .catch((err) => {
         const { message, position } = err;
         if (message && position >= 1) {
           const endLineWrapIndexOf = string.indexOf('\n', position);
@@ -72,11 +73,28 @@ ${err}
     select,
     column,
 
-    close: () => {
-      client_active = false;
-      if (client) {
-        client.end();
-      }
-    },
+    addBeforeCloseListener: listener => beforeCloseListeners.push(listener),
+
+    close: () =>
+      beforeCloseListeners
+        .reduce(
+          (promise, listener) =>
+            promise
+              .then(listener)
+              .catch(err =>
+                console.err(
+                  err.stack
+                    ? err.stack
+                    : err
+                )
+              ),
+          Promise.resolve()
+        )
+        .then(() => {
+          client_active = false;
+          if (client) {
+            client.end();
+          }
+        }),
   };
 };

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -12,6 +12,7 @@ import path from 'path';
 import util from 'util';
 
 import MigrationBuilder from './migration-builder';
+import { getMigrationTableSchema } from './utils';
 
 class Migration {
 
@@ -56,7 +57,7 @@ class Migration {
     }).then(() => {
       const sql_steps = pgm.getSqlSteps();
 
-      const schema = this.options.migrations_schema || this.options.schema || 'public';
+      const schema = getMigrationTableSchema(this.options);
       switch (action) {
         case this.down:
           this.log(`### MIGRATION ${this.name} (DOWN) ###`);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -55,19 +55,16 @@ const lock = (db, options) => {
         return null;
       });
 
-  return getCurrentLockName()
+  return db.query(`BEGIN`)
+    .then(() => db.query(`LOCK "${schema}"."${options.migrations_table}" IN ACCESS EXCLUSIVE MODE`))
+    .then(getCurrentLockName)
     .then((currentLockName) => {
       if (currentLockName) {
         throw new Error('Another migration is already running');
       }
     })
     .then(() => db.query(`COMMENT ON TABLE "${schema}"."${options.migrations_table}" IS '${lockName}'`))
-    .then(getCurrentLockName)
-    .then((currentLockName) => {
-      if (currentLockName !== lockName) {
-        throw new Error('Another migration is already running');
-      }
-    });
+    .then(() => db.query(`COMMIT`));
 };
 
 const unlock = (db, options) => {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,8 +1,10 @@
 import _ from 'lodash';
 import path from 'path';
+import crypto from 'crypto';
 import fs from 'fs';
 import Db from './db';
 import Migration from './migration';
+import { getMigrationTableSchema, finallyPromise } from './utils';
 
 const readdir = (...args) =>
   new Promise((resolve, reject) =>
@@ -36,12 +38,55 @@ const loadMigrationFiles = (db, options) =>
       throw new Error(`Can't get migration files: ${err.stack}`);
     });
 
+const lock = (db, options) => {
+  const schema = getMigrationTableSchema(options);
+  const lockName = crypto.randomBytes(30).toString('base64');
+  const getCurrentLockName = () =>
+    db
+      .select(`SELECT obj_description(c.oid) as "comment"
+                FROM pg_class c join pg_namespace n ON (c.relnamespace = n.oid)
+                WHERE c.relname = '${options.migrations_table}' and c.relkind = 'r' and n.nspname = '${schema}'`)
+      .then((rows) => {
+        if (rows.length > 1) {
+          throw new Error('More then one migration table');
+        } else if (rows.length === 1) {
+          return rows[0].comment;
+        }
+        return null;
+      });
+
+  return getCurrentLockName()
+    .then((currentLockName) => {
+      if (currentLockName) {
+        throw new Error('Another migration is already running');
+      }
+    })
+    .then(() => db.query(`COMMENT ON TABLE "${schema}"."${options.migrations_table}" IS '${lockName}'`))
+    .then(getCurrentLockName)
+    .then((currentLockName) => {
+      if (currentLockName !== lockName) {
+        throw new Error('Another migration is already running');
+      }
+    });
+};
+
+const unlock = (db, options) => {
+  const schema = getMigrationTableSchema(options);
+  return db.query(`COMMENT ON TABLE "${schema}"."${options.migrations_table}" IS NULL`);
+};
+
 const getRunMigrations = (db, options) => {
-  const schema = options.migrations_schema || options.schema || 'public';
+  const schema = getMigrationTableSchema(options);
   return db.select(`SELECT table_name FROM information_schema.tables WHERE table_schema = '${schema}' AND table_name = '${options.migrations_table}'`)
     .then(migrationTables =>
       (migrationTables && migrationTables.length === 1)
       || db.query(`CREATE TABLE "${schema}"."${options.migrations_table}" ( id SERIAL, ${nameColumn} varchar(255) NOT NULL, ${runOnColumn} timestamp NOT NULL)`)
+    )
+    .then(() =>
+      lock(db, options)
+    )
+    .then(() =>
+      db.addBeforeCloseListener(() => unlock(db, options))
     )
     .then(() =>
       db.column(`SELECT ${nameColumn} FROM "${schema}"."${options.migrations_table}" ORDER BY ${runOnColumn}`, nameColumn)
@@ -122,8 +167,16 @@ export default (options) => {
     })
     .catch((e) => {
       console.log('> Rolling back attempted migration ...');
-      db.close();
-      throw e;
+      return db.query('ROLLBACK')
+        .then(...finallyPromise(() => {
+          throw e;
+        }));
     })
-    .then(db.close);
+    .then(...finallyPromise(db.close));
+};
+
+export const unlockRunner = (options) => {
+  const db = Db(options.database_url);
+  return unlock(db, options)
+    .then(...finallyPromise(db.close));
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,13 +29,24 @@ export const t = (s, d) =>
     .reduce((str, p) => str.replace(new RegExp(`{${p}}`, 'g'), schemalize(d[p])), s);
 
 export const escapeValue = (val) => {
-  // TODO: figure out a solution for unescaping functions -- ex: NOW()
-  if (val === null) return 'NULL';
-  if (typeof val === 'boolean') return val.toString();
-  if (typeof val === 'string') return `'${escape(val)}'`;
-  if (typeof val === 'number') return val;
-  if (Array.isArray(val)) return `ARRAY[${val.map(escapeValue).join(',').replace(/ARRAY/g, '')}]`;
-  if (val instanceof PgLiteral) return val.toString();
+  if (val === null) {
+    return 'NULL';
+  }
+  if (typeof val === 'boolean') {
+    return val.toString();
+  }
+  if (typeof val === 'string') {
+    return `'${escape(val)}'`;
+  }
+  if (typeof val === 'number') {
+    return val;
+  }
+  if (Array.isArray(val)) {
+    return `ARRAY[${val.map(escapeValue).join(',').replace(/ARRAY/g, '')}]`;
+  }
+  if (val instanceof PgLiteral) {
+    return val.toString();
+  }
   return '';
 };
 
@@ -46,3 +57,31 @@ export const template = (strings, ...keys) => {
   });
   return result.join('');
 };
+
+export const getMigrationTableSchema = options => options.migrations_schema || options.schema || 'public';
+
+export const finallyPromise = func => [
+  func,
+  (err) => {
+    const errHandler = (innerErr) => {
+      console.err(
+        innerErr.stack
+          ? innerErr.stack
+          : innerErr
+      );
+      throw err;
+    };
+    try {
+      return Promise
+        .resolve(func())
+        .then(
+          () => {
+            throw err;
+          },
+          errHandler
+        );
+    } catch (innerErr) {
+      return errHandler(innerErr);
+    }
+  },
+];


### PR DESCRIPTION
Fixes #72 
I found several options:
* lock migration table - it is not doable because it needs to be wrapped in transaction and we are (optionally) locking each migration in transaction and it can be switched off because some DDL can't be in transaction
* using [Shared data](https://www.postgresql.org/docs/current/static/plpython-sharing.html) but it needs python extension installed and it can be done only with administrator rights
* using temporal tables - it also needs to have extension installed
* using extra table - it have benefit that it can store some additional info and it can check and set lock in one command (aka `UPDATE/INSERT INTO xxx WHERE lock IS NULL`) but I do not want to pollute schema with another table
* maybe there are other options but it will be probably roughly same as using comment on table I decided to use.