### PR TITLE
Add support for TypeScript migrations

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -26,7 +26,6 @@ const loadMigrationFiles = (db, options) =>
   readdir(`${options.dir}/`)
     .then(files =>
       _.chain(files)
-        .filter(file => file.match(/^[0-9]+_/g) !== null)
         .map((file) => {
           const file_path = `${options.dir}/${file}`;
           // eslint-disable-next-line global-require,import/no-dynamic-require

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -26,7 +26,7 @@ const loadMigrationFiles = (db, options) =>
   readdir(`${options.dir}/`)
     .then(files =>
       _.chain(files)
-        .filter(file => file.match(/.+\.js$/g) !== null && file !== 'index.js')
+        .filter(file => file.match(/^[0-9]+_/g) !== null)
         .map((file) => {
           const file_path = `${options.dir}/${file}`;
           // eslint-disable-next-line global-require,import/no-dynamic-require


### PR DESCRIPTION
I'm using TypeScript to write the migrations, and so my migration files have names ending in `.ts` — e.g. `1498187431084_CreateDocumentsTable.ts`.

This change adjusts the search algorithm to simply look for files prefixed with numbers and an underscore, and expects that users will ensure that files with such names are importable migrations.