### PR TITLE
Support object with schema and table name in more places

### DIFF
--- a/lib/operations/indexes.js
+++ b/lib/operations/indexes.js
@@ -1,7 +1,10 @@
 import _ from 'lodash';
 import { template } from '../utils';
 
-function generateIndexName(table_name, columns, options) {
+function generateIndexName(table, columns, options) {
+  const table_name = typeof table === 'object'
+    ? table.name
+    : table;
   return options.name
     ? options.name
     : template`${table_name}_${_.isArray(columns) ? columns.join('_') : columns}${options.unique ? '_unique' : ''}_index`;

--- a/lib/operations/tables.js
+++ b/lib/operations/tables.js
@@ -35,7 +35,7 @@ function parseColumns(columns, table_name, extending_type_shorthands = {}) {
       constraints.push(`CHECK (${options.check})`);
     }
     if (options.references) {
-      constraints.push(`REFERENCES ${options.references}`);
+      constraints.push(template`REFERENCES "${options.references}"`);
       if (options.onDelete) {
         constraints.push(`ON DELETE ${options.onDelete}`);
       }

--- a/lib/operations/tables.js
+++ b/lib/operations/tables.js
@@ -1,11 +1,13 @@
 import _ from 'lodash';
 import { escapeValue, template, quote, applyType, applyTypeAdapters } from '../utils';
 
-function parseColumns(columns, table_name, extending_type_shorthands = {}) {
+function parseColumns(columns, table, extending_type_shorthands = {}) {
   let columnsWithOptions = _.mapValues(
     columns,
     column => applyType(column, extending_type_shorthands)
   );
+
+  const table_name = typeof table === 'object' ? table.name : table;
 
   const primaryColumns = _.chain(columnsWithOptions)
     .map((options, column_name) => (options.primaryKey ? column_name : null))

--- a/test/indexes-test.js
+++ b/test/indexes-test.js
@@ -1,0 +1,11 @@
+import { expect } from 'chai';
+import * as Indexes from '../lib/operations/indexes';
+
+describe('lib/operations/indexes', () => {
+  describe('.create', () => {
+    it('check schema not included in index name', () => {
+      const sql = Indexes.create({ schema: 'a', name: 'b' }, ['c', 'd']);
+      expect(sql).to.equal('CREATE  INDEX  "b_c_d_index" ON "a"."b" ("c", "d");');
+    });
+  });
+});

--- a/test/tables-test.js
+++ b/test/tables-test.js
@@ -23,5 +23,12 @@ describe('lib/operations/tables', () => {
   "id" uuid PRIMARY KEY
 );`);
     });
+
+    it('check schemas can be used for foreign keys', () => {
+      const sql = Tables.create()('my_table_name', { parent_id: { type: 'integer', references: { schema: 'a', name: 'b' } } });
+      expect(sql).to.equal(`CREATE TABLE "my_table_name" (
+  "parent_id" integer REFERENCES "a"."b"
+);`);
+    });
   });
 });

--- a/test/tables-test.js
+++ b/test/tables-test.js
@@ -30,5 +30,17 @@ describe('lib/operations/tables', () => {
   "parent_id" integer REFERENCES "a"."b"
 );`);
     });
+
+    it('check multicolumn primary key name does not include schema', () => {
+      const sql = Tables.create()({ schema: 's', name: 'my_table_name' }, {
+        a: { type: 'integer', primaryKey: true },
+        b: { type: 'varchar', primaryKey: true },
+      });
+      expect(sql).to.equal(`CREATE TABLE "s"."my_table_name" (
+  "a" integer,
+  "b" varchar,
+  CONSTRAINT "my_table_name_pkey" PRIMARY KEY ("a", "b")
+);`);
+    });
   });
 });


### PR DESCRIPTION
* Allow using an object with schema and table name as value for the `references` key to setup a foreign key constraint.
* If an object with schema and table name is passed to `createIndex` don't include the schema when generating a name for the index.
* When generating a constraint name for a composite primary key get the table name out of an object if necessary to avoid including `[object Object]` in the name.