### PR TITLE
Fix automatic reversal of addColumns

### DIFF
--- a/lib/operations/tables.js
+++ b/lib/operations/tables.js
@@ -83,9 +83,6 @@ export const create = (type_shorthands) => {
   return _create;
 };
 
-export const addColumns = type_shorthands => (table_name, columns) =>
-  template`ALTER TABLE "${table_name}"\n${parseColumns(columns, table_name, type_shorthands).replace(/^/gm, '  ADD ')};`;
-
 export const dropColumns = (table_name, columns) => {
   if (typeof columns === 'string') {
     columns = [columns]; // eslint-disable-line no-param-reassign
@@ -93,6 +90,13 @@ export const dropColumns = (table_name, columns) => {
     columns = _.keys(columns); // eslint-disable-line no-param-reassign
   }
   return template`ALTER TABLE "${table_name}"\n${quote(columns).join(',\n').replace(/^/gm, '  DROP ')};`;
+};
+
+export const addColumns = (type_shorthands) => {
+  const _add = (table_name, columns) =>
+    template`ALTER TABLE "${table_name}"\n${parseColumns(columns, table_name, type_shorthands).replace(/^/gm, '  ADD ')};`;
+  _add.reverse = dropColumns;
+  return _add;
 };
 
 export const alterColumn = (table_name, column_name, options) => {


### PR DESCRIPTION
The reverse operation needs to be specified on the function which has a
closure around the type_shorthands in order for the reverse operation to
be found by the migration builder.