### PR TITLE
Update documentation for custom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,14 @@ or
 }
 ```
 
-if using your own custom config file:
+You could also specify your database url by setting the environment variable `DATABASE_URL`.
+
+```
+DATABASE_URL=postgres://postgres@localhost/name node-pg-migrate
+```
+
+You can specify custom JSON file with config (format is same as for `db` entry of [config](https://www.npmjs.com/package/config) file), for example:
+
 ```json
 // path/to/config.json
 {
@@ -53,14 +60,6 @@ if using your own custom config file:
   "name": "name"
 }
 ```
-
-You could also specify your database url by setting the environment variable `DATABASE_URL`.
-
-```
-DATABASE_URL=postgres://postgres@localhost/name node-pg-migrate
-```
-
-You can specify custom JSON file with config (format is same as for `db` entry of [config](https://www.npmjs.com/package/config) file)
 
 If a .env file exists, it will be loaded using [dotenv](https://www.npmjs.com/package/dotenv) (if installed) when running the pg-migrate binary.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ or
 }
 ```
 
+if using your own custom config file:
+```json
+// path/to/config.json
+{
+  "user": "postgres",
+  "password": "",
+  "host": "localhost",
+  "port": 5432,
+  "name": "name"
+}
+```
+
 You could also specify your database url by setting the environment variable `DATABASE_URL`.
 
 ```


### PR DESCRIPTION
Using a custom config does not look for things with the key called "db", so either the code should look for db, or update the documentation to reflect this.