### PR TITLE
Adds default clause to Column Definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,8 @@ The `createTable` and `addColumns` methods both take a `columns` argument that s
 - `references` _[string]_ - a table name that this column is a foreign key to
 - `onDelete` _[string]_ - adds ON DELETE constraint for a reference column
 - `onUpdate` _[string]_ - adds ON UPDATE constraint for a reference column
+- `default` _[string]_ - adds DEFAULT clause for column
+
 
 #### Data types & Convenience Shorthand
 Data type strings will be passed through directly to postgres, so write types as you would if you were writing the queries by hand.

--- a/README.md
+++ b/README.md
@@ -631,7 +631,6 @@ The `createTable` and `addColumns` methods both take a `columns` argument that s
 - `onUpdate` _[string]_ - adds ON UPDATE constraint for a reference column
 - `default` _[string]_ - adds DEFAULT clause for column
 
-
 #### Data types & Convenience Shorthand
 Data type strings will be passed through directly to postgres, so write types as you would if you were writing the queries by hand.
 


### PR DESCRIPTION
I noticed that `default` worked when including it in the column definition but was missing in the docs.