### PR TITLE
Change foreign key constraints to emit valid SQL

### DIFF
--- a/lib/operations/tables.js
+++ b/lib/operations/tables.js
@@ -119,7 +119,7 @@ const parseConstraints = (table, options) => {
         const {
           columns,
         } = fk;
-        constraints.push(`FOREIGN KEY "${_.isArray(columns) ? columns.join('", "') : columns}" ${parseReferences(fk)}`);
+        constraints.push(`FOREIGN KEY (${_.isArray(columns) ? columns.join(', ') : columns}) ${parseReferences(fk)}`);
       });
   }
   if (exclude) {


### PR DESCRIPTION
This addresses my comment in #114 regarding foreign key constraints in the options argument for `createTable`.

* Remove quotes from column names.
* Add parenthesis around column names.
* Remove quotes from between column names when more than one column is specified.